### PR TITLE
Fix/9 sort order

### DIFF
--- a/.github/workflows/parse-and-generate.yml
+++ b/.github/workflows/parse-and-generate.yml
@@ -4,7 +4,7 @@ on:
   push:
   workflow_dispatch:
   schedule:
-    - cron: '0 14 * * *' # every day at noon UTC plus two hours, since COTA publishes their stuff around 9 a.m. Eastern
+    - cron: '0 2,14 * * *' # every day at noon UTC plus two hours, since COTA publishes their stuff around 9 a.m. Eastern. Also at 10 p.m. Eastern to catch evening updates before the morning commute.
 
 permissions:
   contents: write

--- a/.github/workflows/parse-and-generate.yml
+++ b/.github/workflows/parse-and-generate.yml
@@ -4,7 +4,7 @@ on:
   push:
   workflow_dispatch:
   schedule:
-    - cron: '0 12 * * *' # every day at noon, in whatever timezone Github uses
+    - cron: '0 14 * * *' # every day at noon UTC plus two hours, since COTA publishes their stuff around 9 a.m. Eastern
 
 permissions:
   contents: write

--- a/alerts-log.csv
+++ b/alerts-log.csv
@@ -9,3 +9,4 @@ header,description,link_title,link_url,link_target,time
 "REROUTES AHEAD","MAY 4 | ON OUR SLEEVES 5K","LEARN MORE",https://www.cota.com/reroutes/cota-reroute-on-our-sleeves-5k-240504.pdf,,1714825360
 "REROUTES AHEAD","MAY 18-19 | SUSAN G. KOMEN RACE FOR THE CURE & GIRLS ON THE RUN 5K","LEARN MORE",https://www.cota.com/reroutes/cota-reroutes-komen-girls-run-240518.pdf,,1715776067
 "REROUTES AHEAD","MAY 18-19 | SUSAN G. KOMEN RACE FOR THE CURE & GIRLS ON THE RUN 5K","LEARN MORE",https://www.cota.com/blog/major-reroutes-and-delays-expected-for-susan-g-komen-race-for-the-cure-and-girls-on-the-run-5k-this-weekend/,,1715948724
+"REROUTES AHEAD","JUNE 1-2 | BRAIN TUMOR 5K & COLUMBUS 10K","LEARN MORE",https://www.cota.com/reroutes/,,1717092160

--- a/parser.php
+++ b/parser.php
@@ -82,17 +82,40 @@ function iterate( $json_handle, $csv_handle ) {
 
         error_log( var_export( $new_entry, true ) );
 
+        $check_value = generate_csv_line_for_checking( $new_entry );
+
         // check if the link_url exists in the file already
-        if ( ! str_contains( $csv_contents, $new_entry['link_url'] ) ) {
+        if ( ! str_contains( $csv_contents, $check_value ) ) {
             // if not, then write it to the file
             fputcsv(
                 $csv_handle,
                 $new_entry
             );
             rewind( $csv_handle );
+        } else {
+            error_log( "\n" );
+            error_log( "Item not added to CSV because it already exists:" );
+            error_log( var_export( $check_value, true ) );
         }
     }
 };
+
+/**
+ * Generate a line for the CSV, for checking purposes
+ *
+ * @link https://www.php.net/manual/en/function.fputcsv.php#74118
+ */
+function generate_csv_line_for_checking( $entry ) {
+    $csv = fopen('php://temp/maxmemory:'. (5*1024*1024), 'r+');
+
+    // this changes from one run to the next; we don't need to incorporate it in the check
+    unset( $entry['time'] );
+    fputcsv( $csv, $entry );
+    rewind( $csv );
+    $output = trim( stream_get_contents( $csv ) );
+
+    return $output;
+}
 
 /**
  * Main

--- a/rss.php
+++ b/rss.php
@@ -37,6 +37,8 @@ function escape( $string ) {
  */
 function iterate( $handle ) {
 	$iterator = 0;
+	$entries  = [];
+
 	while ( ( $data = fgetcsv( $handle, 1000 ) ) !== false ) {
 		$iterator++;
 		// skip over the header row.
@@ -70,6 +72,7 @@ function iterate( $handle ) {
 
 		$pubDate = date_format( DateTimeImmutable::createFromFormat( 'U', $data[5] ), DATE_RSS );
 
+		ob_start();
 		?>
 			<item>
 				<title><?php echo $title; ?></title>
@@ -79,9 +82,10 @@ function iterate( $handle ) {
 				<guid><?php echo $link; ?></guid>
 			</item>
 		<?php
+		$entries[] = trim( ob_get_clean() );
+	} // endwhile
 
-		echo "\n";
-	}
+	echo implode( "\n", array_reverse( $entries ) );
 }
 
 ?>

--- a/rss.xml
+++ b/rss.xml
@@ -6,85 +6,81 @@
 		<language>en-us</language>
 		<atom:link href="https://raw.githubusercontent.com/benlk/cota-reroute-pdf-rss/main/rss.xml" rel="self" type="application/rss+xml"/>
 
-					<item>
-				<title>REROUTES AHEAD: Dec. 2 | Holiday Hop</title>
-				<link>https://www.cota.com/reroutes/cota-reroutes-holiday-hop-231202.pdf</link>
-				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroutes-holiday-hop-231202.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroutes-holiday-hop-231202.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
-				<pubDate>Sat, 02 Dec 2023 00:59:07 +0000</pubDate>
-				<guid>https://www.cota.com/reroutes/cota-reroutes-holiday-hop-231202.pdf</guid>
+		<item>
+				<title>REROUTES AHEAD: JUNE 1-2 | BRAIN TUMOR 5K &amp; COLUMBUS 10K</title>
+				<link>https://www.cota.com/reroutes/</link>
+				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/">LEARN MORE: https://www.cota.com/reroutes/</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
+				<pubDate>Thu, 30 May 2024 18:02:40 +0000</pubDate>
+				<guid>https://www.cota.com/reroutes/</guid>
 			</item>
-		
-			<item>
-				<title>REROUTES AHEAD: Dec. 12 | Columbus Crew Parade</title>
-				<link>https://www.cota.com/reroutes/cota-reroutes-crew-parade-231212.pdf</link>
-				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroutes-crew-parade-231212.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroutes-crew-parade-231212.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
-				<pubDate>Sat, 02 Dec 2023 00:59:08 +0000</pubDate>
-				<guid>https://www.cota.com/reroutes/cota-reroutes-crew-parade-231212.pdf</guid>
-			</item>
-		
-			<item>
-				<title>REROUTES AHEAD: Feb. 11 | 5th Line 5K</title>
-				<link>https://www.cota.com/reroutes/cota-reroutes-5th-line-5k-240211.pdf</link>
-				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroutes-5th-line-5k-240211.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroutes-5th-line-5k-240211.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
-				<pubDate>Mon, 12 Feb 2024 15:38:34 +0000</pubDate>
-				<guid>https://www.cota.com/reroutes/cota-reroutes-5th-line-5k-240211.pdf</guid>
-			</item>
-		
-			<item>
-				<title>REROUTES AHEAD: March 9 | Dublin St. Patrick's Day Parade</title>
-				<link>https://www.cota.com/reroutes/cota-reroutes-dublin-st-patricks-parade-240309.pdf</link>
-				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroutes-dublin-st-patricks-parade-240309.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroutes-dublin-st-patricks-parade-240309.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
-				<pubDate>Mon, 11 Mar 2024 19:14:12 +0000</pubDate>
-				<guid>https://www.cota.com/reroutes/cota-reroutes-dublin-st-patricks-parade-240309.pdf</guid>
-			</item>
-		
-			<item>
-				<title>REROUTES AHEAD: March 17 | Shamrock Parade</title>
-				<link>https://www.cota.com/reroutes/cota-reroutes-shamrock-parade-240317.pdf</link>
-				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroutes-shamrock-parade-240317.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroutes-shamrock-parade-240317.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
-				<pubDate>Fri, 15 Mar 2024 12:23:12 +0000</pubDate>
-				<guid>https://www.cota.com/reroutes/cota-reroutes-shamrock-parade-240317.pdf</guid>
-			</item>
-		
-			<item>
-				<title>REROUTES AHEAD: April 13-14 | Ohio State Spring Game &amp; 4 Miler</title>
-				<link>https://author.cota.com/wp-content/uploads/2024/04/cota-reroutes-osu-game-day-4-miler-240413.pdf</link>
-				<description><![CDATA[<p><a href="https://author.cota.com/wp-content/uploads/2024/04/cota-reroutes-osu-game-day-4-miler-240413.pdf">LEARN MORE: https://author.cota.com/wp-content/uploads/2024/04/cota-reroutes-osu-game-day-4-miler-240413.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
-				<pubDate>Fri, 12 Apr 2024 12:24:07 +0000</pubDate>
-				<guid>https://author.cota.com/wp-content/uploads/2024/04/cota-reroutes-osu-game-day-4-miler-240413.pdf</guid>
-			</item>
-		
-			<item>
-				<title>REROUTES AHEAD: APRIL 26-27 | CAP CITY HALF MARATHON</title>
-				<link>https://www.cota.com/reroutes/cota-reroutes-cap-city-half-marathon-240426.pdf</link>
-				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroutes-cap-city-half-marathon-240426.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroutes-cap-city-half-marathon-240426.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
-				<pubDate>Wed, 24 Apr 2024 12:29:06 +0000</pubDate>
-				<guid>https://www.cota.com/reroutes/cota-reroutes-cap-city-half-marathon-240426.pdf</guid>
-			</item>
-		
-			<item>
-				<title>REROUTES AHEAD: MAY 4 | ON OUR SLEEVES 5K</title>
-				<link>https://www.cota.com/reroutes/cota-reroute-on-our-sleeves-5k-240504.pdf</link>
-				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroute-on-our-sleeves-5k-240504.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroute-on-our-sleeves-5k-240504.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
-				<pubDate>Sat, 04 May 2024 12:22:40 +0000</pubDate>
-				<guid>https://www.cota.com/reroutes/cota-reroute-on-our-sleeves-5k-240504.pdf</guid>
-			</item>
-		
-			<item>
-				<title>REROUTES AHEAD: MAY 18-19 | SUSAN G. KOMEN RACE FOR THE CURE &amp; GIRLS ON THE RUN 5K</title>
-				<link>https://www.cota.com/reroutes/cota-reroutes-komen-girls-run-240518.pdf</link>
-				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroutes-komen-girls-run-240518.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroutes-komen-girls-run-240518.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
-				<pubDate>Wed, 15 May 2024 12:27:47 +0000</pubDate>
-				<guid>https://www.cota.com/reroutes/cota-reroutes-komen-girls-run-240518.pdf</guid>
-			</item>
-		
-			<item>
+<item>
 				<title>REROUTES AHEAD: MAY 18-19 | SUSAN G. KOMEN RACE FOR THE CURE &amp; GIRLS ON THE RUN 5K</title>
 				<link>https://www.cota.com/blog/major-reroutes-and-delays-expected-for-susan-g-komen-race-for-the-cure-and-girls-on-the-run-5k-this-weekend/</link>
 				<description><![CDATA[<p><a href="https://www.cota.com/blog/major-reroutes-and-delays-expected-for-susan-g-komen-race-for-the-cure-and-girls-on-the-run-5k-this-weekend/">LEARN MORE: https://www.cota.com/blog/major-reroutes-and-delays-expected-for-susan-g-komen-race-for-the-cure-and-girls-on-the-run-5k-this-weekend/</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
 				<pubDate>Fri, 17 May 2024 12:25:24 +0000</pubDate>
 				<guid>https://www.cota.com/blog/major-reroutes-and-delays-expected-for-susan-g-komen-race-for-the-cure-and-girls-on-the-run-5k-this-weekend/</guid>
 			</item>
-		
-	</channel>
+<item>
+				<title>REROUTES AHEAD: MAY 18-19 | SUSAN G. KOMEN RACE FOR THE CURE &amp; GIRLS ON THE RUN 5K</title>
+				<link>https://www.cota.com/reroutes/cota-reroutes-komen-girls-run-240518.pdf</link>
+				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroutes-komen-girls-run-240518.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroutes-komen-girls-run-240518.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
+				<pubDate>Wed, 15 May 2024 12:27:47 +0000</pubDate>
+				<guid>https://www.cota.com/reroutes/cota-reroutes-komen-girls-run-240518.pdf</guid>
+			</item>
+<item>
+				<title>REROUTES AHEAD: MAY 4 | ON OUR SLEEVES 5K</title>
+				<link>https://www.cota.com/reroutes/cota-reroute-on-our-sleeves-5k-240504.pdf</link>
+				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroute-on-our-sleeves-5k-240504.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroute-on-our-sleeves-5k-240504.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
+				<pubDate>Sat, 04 May 2024 12:22:40 +0000</pubDate>
+				<guid>https://www.cota.com/reroutes/cota-reroute-on-our-sleeves-5k-240504.pdf</guid>
+			</item>
+<item>
+				<title>REROUTES AHEAD: APRIL 26-27 | CAP CITY HALF MARATHON</title>
+				<link>https://www.cota.com/reroutes/cota-reroutes-cap-city-half-marathon-240426.pdf</link>
+				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroutes-cap-city-half-marathon-240426.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroutes-cap-city-half-marathon-240426.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
+				<pubDate>Wed, 24 Apr 2024 12:29:06 +0000</pubDate>
+				<guid>https://www.cota.com/reroutes/cota-reroutes-cap-city-half-marathon-240426.pdf</guid>
+			</item>
+<item>
+				<title>REROUTES AHEAD: April 13-14 | Ohio State Spring Game &amp; 4 Miler</title>
+				<link>https://author.cota.com/wp-content/uploads/2024/04/cota-reroutes-osu-game-day-4-miler-240413.pdf</link>
+				<description><![CDATA[<p><a href="https://author.cota.com/wp-content/uploads/2024/04/cota-reroutes-osu-game-day-4-miler-240413.pdf">LEARN MORE: https://author.cota.com/wp-content/uploads/2024/04/cota-reroutes-osu-game-day-4-miler-240413.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
+				<pubDate>Fri, 12 Apr 2024 12:24:07 +0000</pubDate>
+				<guid>https://author.cota.com/wp-content/uploads/2024/04/cota-reroutes-osu-game-day-4-miler-240413.pdf</guid>
+			</item>
+<item>
+				<title>REROUTES AHEAD: March 17 | Shamrock Parade</title>
+				<link>https://www.cota.com/reroutes/cota-reroutes-shamrock-parade-240317.pdf</link>
+				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroutes-shamrock-parade-240317.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroutes-shamrock-parade-240317.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
+				<pubDate>Fri, 15 Mar 2024 12:23:12 +0000</pubDate>
+				<guid>https://www.cota.com/reroutes/cota-reroutes-shamrock-parade-240317.pdf</guid>
+			</item>
+<item>
+				<title>REROUTES AHEAD: March 9 | Dublin St. Patrick's Day Parade</title>
+				<link>https://www.cota.com/reroutes/cota-reroutes-dublin-st-patricks-parade-240309.pdf</link>
+				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroutes-dublin-st-patricks-parade-240309.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroutes-dublin-st-patricks-parade-240309.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
+				<pubDate>Mon, 11 Mar 2024 19:14:12 +0000</pubDate>
+				<guid>https://www.cota.com/reroutes/cota-reroutes-dublin-st-patricks-parade-240309.pdf</guid>
+			</item>
+<item>
+				<title>REROUTES AHEAD: Feb. 11 | 5th Line 5K</title>
+				<link>https://www.cota.com/reroutes/cota-reroutes-5th-line-5k-240211.pdf</link>
+				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroutes-5th-line-5k-240211.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroutes-5th-line-5k-240211.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
+				<pubDate>Mon, 12 Feb 2024 15:38:34 +0000</pubDate>
+				<guid>https://www.cota.com/reroutes/cota-reroutes-5th-line-5k-240211.pdf</guid>
+			</item>
+<item>
+				<title>REROUTES AHEAD: Dec. 12 | Columbus Crew Parade</title>
+				<link>https://www.cota.com/reroutes/cota-reroutes-crew-parade-231212.pdf</link>
+				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroutes-crew-parade-231212.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroutes-crew-parade-231212.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
+				<pubDate>Sat, 02 Dec 2023 00:59:08 +0000</pubDate>
+				<guid>https://www.cota.com/reroutes/cota-reroutes-crew-parade-231212.pdf</guid>
+			</item>
+<item>
+				<title>REROUTES AHEAD: Dec. 2 | Holiday Hop</title>
+				<link>https://www.cota.com/reroutes/cota-reroutes-holiday-hop-231202.pdf</link>
+				<description><![CDATA[<p><a href="https://www.cota.com/reroutes/cota-reroutes-holiday-hop-231202.pdf">LEARN MORE: https://www.cota.com/reroutes/cota-reroutes-holiday-hop-231202.pdf</a></p><p>The publication date on this feed reflects the date that the item was scraped from cota.com, not the date that the item was published or pulled down.</p>]]></description>
+				<pubDate>Sat, 02 Dec 2023 00:59:07 +0000</pubDate>
+				<guid>https://www.cota.com/reroutes/cota-reroutes-holiday-hop-231202.pdf</guid>
+			</item>	</channel>
 </rss>


### PR DESCRIPTION
- Resolves #9 
- Resolves an issue where today's feed item wasn't saved because the webpage URL `https://www.cota.com/reroutes/` is a substring of previous reroutes PDF URLs. The new check for existing checks the CSV for the full message, not just the URL.
- Moves the run two hours later in the day to catch late uploads, and adds a second run 12 hours opposite.